### PR TITLE
Use HTTPS for Maven repository

### DIFF
--- a/ivy/ivysettings-public.xml
+++ b/ivy/ivysettings-public.xml
@@ -1,5 +1,5 @@
 <ivysettings>
   <resolvers>
-    <ibiblio name="public" m2compatible="true"/>
+    <ibiblio name="public" m2compatible="true" root="https://repo1.maven.org/maven2"/>
   </resolvers>
 </ivysettings>


### PR DESCRIPTION
Currently, attempting to build ESGF wars results in errors of the form:

```
[ivy:retrieve]  SERVER ERROR: HTTPS Required url=http://repo1.maven.org/maven2/net/sourceforge/cobertura/cobertura/1.9.4/cobertura-1.9.4.pom
```

This change should fix this.